### PR TITLE
Mootools 1.3 and 1.4 compatibility

### DIFF
--- a/Source/mooRainbow.js
+++ b/Source/mooRainbow.js
@@ -174,9 +174,8 @@ var MooRainbow = new Class({
 		}, this);
 		[this.element, this.layout].each(function(el) {
 			el.addEvents({
-				'click': function(e) { new Event(e).stop(); },
+				'click': function(e) { e.stop(); },
 				'keyup': function(e) {
-					e = new Event(e);
 					if(e.key == 'esc' && this.visible) this.hide(this.layout);
 				}.bind(this)
 			}, this);
@@ -194,7 +193,6 @@ var MooRainbow = new Class({
 		});	
 		
 		this.layout.overlay2.addEvent('mousedown', function(e){
-			e = new Event(e);
 			this.layout.cursor.setStyles({
 				'top': e.page.y - this.layout.overlay.getTop() - curH,
 				'left': e.page.x - this.layout.overlay.getLeft() - curW
@@ -239,8 +237,6 @@ var MooRainbow = new Class({
 		});	
 	
 		this.layout.slider.addEvent('mousedown', function(e){
-			e = new Event(e);
-
 			this.layout.arrows.setStyle(
 				'top', e.page.y - this.layout.slider.getTop() + this.snippet('slider') - arwH
 			);

--- a/Source/mooRainbow.js
+++ b/Source/mooRainbow.js
@@ -270,15 +270,23 @@ var MooRainbow = new Class({
 
 		arrColors.each(function(el) {
 			el.addEvents({
-				'mousewheel': this.eventKeys.bindWithEvent(this, el),
-				'keydown': this.eventKeys.bindWithEvent(this, el)
+				'mousewheel': function(e) {
+					this.eventKeys(e, el);
+				}.bind(this),
+				'keydown': function(e) {
+					this.eventKeys(e, el);
+				}.bind(this),
 			});
 		}, this);
 		
 		[this.layout.arrows, this.layout.slider].each(function(el) {
 			el.addEvents({
-				'mousewheel': this.eventKeys.bindWithEvent(this, [this.arrHSB[0], 'slider']),
-				'keydown': this.eventKeys.bindWithEvent(this, [this.arrHSB[0], 'slider'])
+				'mousewheel': function(e) {
+					this.eventKeys(e, this.arrHSB[0], 'slider');
+				}.bind(this),
+				'keydown': function(e) {
+					this.eventKeys(e, this.arrHSB[0], 'slider');
+				}.bind(this)
 			});
 		}, this);
 	},


### PR DESCRIPTION
Hi,

I have just make a couple of fixes that allows mooRainbow class to be executed using mootools 1.3 and 1.4 without compatibility :)

Just removed bindWithEvent and new Event(e). I have tried with mootools 1.4.0, but this two changes are mark as deprecated since 1.3.

Sorry, I think we are using different line endings (I use Unix style: LF) and header is mark as changed but it has no changes

Hope it helps :)

Best regards,

  Fran (aka Tatai)
